### PR TITLE
Some more fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,11 @@ RUN apt $APT_ARGS update \
     echo 'APT::Install-Suggests "0";' ; \
   } > "$APT_CONF_NOBLOAT" \
   && apt $APT_ARGS full-upgrade \
-  && apt $APT_ARGS install libxml2-utils jq devscripts python3-pip python3-setuptools \
+  && apt $APT_ARGS install \
+    libxml2-utils \
+    jq \
+    devscripts libwww-perl gnupg2 \
+    python3-pip python3-setuptools \
   && pip3 install --no-cache-dir yq \
   && apt $APT_ARGS autoremove \
   && apt $APT_ARGS autoclean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,20 @@
 FROM debian:buster-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG APT_CONF_NOBLOAT='/etc/apt/apt.conf.d/01nobloat'
+ARG APT_ARGS='-y -qq -o=Dpkg::Use-Pty=0'
 
-RUN apt update \
-  && apt -y full-upgrade \
-  && apt -y install libxml2-utils jq devscripts python3-pip \
-  && apt -y autoremove \
-  && apt -y autoclean \
-  && rm -rf /var/lib/apt/lists/* \
-  && pip3 install yq
-
-
+RUN apt $APT_ARGS update \
+  && { \
+    echo 'APT::Install-Recommends "0";' ; \
+    echo 'APT::Install-Suggests "0";' ; \
+  } > "$APT_CONF_NOBLOAT" \
+  && apt $APT_ARGS full-upgrade \
+  && apt $APT_ARGS install libxml2-utils jq devscripts python3-pip python3-setuptools \
+  && pip3 install --no-cache-dir yq \
+  && apt $APT_ARGS autoremove \
+  && apt $APT_ARGS autoclean \
+  && rm -rf /var/lib/apt/lists/* "$APT_CONF_NOBLOAT"
 
 COPY assets /opt/resource/
 

--- a/build_and_push.sh
+++ b/build_and_push.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+test -z "${DEBUG:-}" || set -x
+
+if [ -z "${1:-}" ]
+then
+    DIR="$( dirname "$(readlink -f "$0")" )"
+else
+    DIR="$1"
+fi
+
+trap "cd '${PWD}'" EXIT
+cd "$DIR"
+
+: "${NAME="$(basename "$DIR")"}"
+: "${VER:=latest}"
+: "${REPO:=cflondonservices}"
+
+GIT_REV="$( git rev-parse HEAD )"
+CUR_DATE="$( date -u '+%Y-%m-%dT%H:%M:%SZ' )"
+DIRTY="$(
+    [ "$(git status --porcelain | wc -l)" = 0 ] || {
+        echo '-dirty'
+    }
+)"
+
+TAG_DATE="${REPO}/${NAME}:${CUR_DATE//:/.}"  # tags with : are not allowed
+TAG_VER="${REPO}/${NAME}:${VER}"
+
+docker build \
+    --label org.label-schema.vcs-rev="${GIT_REV}${DIRTY}" \
+    --label org.label-schema.build-date="${CUR_DATE}" \
+    --tag "$TAG_VER" \
+    --tag "$TAG_DATE" \
+    .
+
+if [ -n "${PUSH_WHEN_DIRTY:-}" -o -z "$DIRTY" ]
+then
+    docker push "${REPO}/${NAME}"
+else
+    echo 'Not pushing, working dir is dirty' >&2
+fi


### PR DESCRIPTION
- Make image small
  -  not installing recommendations/suggestions: I could not reproduce the installation problems with neither `libxml2-utils` nor with `yq` (at least as soon as `python3-setuptools` is installed).
  - using `--no-cache-dir` for `pip` to create a clean image
- Make `apt` a little less talkative
- Adding helper script for tagging/pushing/...